### PR TITLE
macOS 11 runner image retired

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
           tfcmt --version
 
   test-darwin:
-    runs-on: macos-11
+    runs-on: macos-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
ref. https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/