### PR TITLE
fix: exact match for gz files in hash_sha256_verify

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -326,7 +326,7 @@ hash_sha256_verify() {
   BASENAME=${TARGET##*/}
   log_debug $BASENAME
   log_debug $TARGET
-  want=$(grep "${BASENAME}" "${checksums}" 2>/dev/null | tr '\t' ' ' | cut -d ' ' -f 1)
+  want=$(grep "${BASENAME}$" "${checksums}" 2>/dev/null | tr '\t' ' ' | cut -d ' ' -f 1)
   if [ -z "$want" ]; then
     log_err "hash_sha256_verify unable to find checksum for '${TARGET}' in '${checksums}'"
     return 1


### PR DESCRIPTION
Hi.

tfcmt v4.14.8 has .sbom.json files like `tfcmt_linux_amd64.tar.gz.sbom.json.
ref: https://github.com/suzuki-shunsuke/tfcmt/releases

This cause following checksum verification error:

```
% bash install.sh
suzuki-shunsuke/tfcmt info checking GitHub for latest tag
suzuki-shunsuke/tfcmt info found version: 4.14.8 for v4.14.8/Linux/arm64
suzuki-shunsuke/tfcmt err hash_sha256_verify checksum for '/tmp/tmp.LhNBsXAyPC/tfcmt_linux_arm64.tar.gz' did not verify fb5a2a70f84c7ac2bf783587ad863a351435a81317a2a184e0d4d1a7e8dc0146
9037d0ab49cacc787f19f8158f95c3574630c11b962f592cd3d54f9921808413 vs fb5a2a70f84c7ac2bf783587ad863a351435a81317a2a184e0d4d1a7e8dc0146
```

I think we need exact match for the tar.gz file.
```
% bash install.sh
suzuki-shunsuke/tfcmt info checking GitHub for latest tag
suzuki-shunsuke/tfcmt info found version: 4.14.8 for v4.14.8/Linux/arm64
suzuki-shunsuke/tfcmt info installed ./bin/tfcmt
```

Could you review my change?
Thank you.